### PR TITLE
🐛 Fixed a bug when quoting values containing single quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 cov.xml
 dist/
 docs/_build
+main.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pySigma-backend-netwitness"
-version = "0.2.1"
+version = "0.2.2"
 description = "pySigma NetWitness backend"
 readme = "README.md"
 authors = ["Marcel Kwaschny <dev@marcelkwaschny.de>"]

--- a/sigma/backends/netwitness/netwitness.py
+++ b/sigma/backends/netwitness/netwitness.py
@@ -202,6 +202,16 @@ class NetWitnessBackend(TextQueryBackend):
 
         return super().decide_string_quoting(s)
 
+    def quote_string(self, s: str) -> str:
+        """Put quotes around string."""
+
+        if "\\'" in s:
+            transformed_string = s.replace("\\'", "'")
+            transformed_string = '"' + transformed_string + '"'
+            return transformed_string
+
+        return super().quote_string(s)
+
     def convert_condition_not(self, cond: ConditionNOT, state: ConversionState) -> Union[str, DeferredQueryExpression]:
         """Conversion of NOT conditions
 

--- a/tests/test_backend_netwitness.py
+++ b/tests/test_backend_netwitness.py
@@ -656,3 +656,30 @@ def test_equal_char_in_list_contains(netwitness_backend: NetWitnessBackend):
     )
 
     assert conversion_result == ["FieldA contains 'field1=value1','field2=value2'"]
+
+
+def test_quoting_if_quote_in_value(netwitness_backend: NetWitnessBackend):
+    """Test conversion of a rule that contains a value that contains a quoting character. If a value
+    contains a single quote then this value has to be quoted with with double quotes instead of
+    single quotes (which is the default).
+    """
+
+    conversion_result: str = netwitness_backend.convert(
+        SigmaCollection.from_yaml(
+            """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                selection:
+                    FieldA|contains|all:
+                        - C:\\WINDOWS
+                        - .exe',
+                condition: selection
+            """
+        )
+    )
+
+    assert conversion_result == ["FieldA contains 'C:\\WINDOWS' && FieldA contains \".exe',\""]


### PR DESCRIPTION
When a value contains single quotes the value has to be wrapped in double quotes instead of the default single quotes.