### PR TITLE
🐛 Fixed a bug using the combination of string conversion and windash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pySigma-backend-netwitness"
-version = "0.2.2"
+version = "0.2.3"
 description = "pySigma NetWitness backend"
 readme = "README.md"
 authors = ["Marcel Kwaschny <dev@marcelkwaschny.de>"]

--- a/sigma/backends/netwitness/transformations.py
+++ b/sigma/backends/netwitness/transformations.py
@@ -1,10 +1,11 @@
 """Custom transformations for the NetWitness backend"""
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional, Union
 
-from sigma.processing.transformations import StringValueTransformation
-from sigma.types import SigmaString
+from sigma.exceptions import SigmaValueError
+from sigma.processing.transformations import StringValueTransformation, ValueTransformation
+from sigma.types import SigmaExpansion, SigmaNumber, SigmaString, SigmaType
 
 from sigma.backends.netwitness.types import SigmaNetWitnessString
 
@@ -17,3 +18,40 @@ class UnquoteStringTransformation(StringValueTransformation):
 
     def apply_string_value(self, field: str, val: SigmaString) -> Optional[SigmaString]:
         return SigmaNetWitnessString(s=val.original, quote=False)
+
+
+@dataclass
+class CustomConvertTypeTransformation(ValueTransformation):
+    """
+    Convert type of value. The conversion into strings and numbers is currently supported.
+    """
+
+    target_type: Literal["str", "num"]
+
+    def apply_value(self, field: str, val: SigmaType) -> Union[SigmaString, SigmaNumber, SigmaExpansion]:
+        if self.target_type == "str":
+            if isinstance(val, SigmaExpansion):
+                for entry in val.values:
+                    entry = SigmaString(str(entry))
+                return val
+            return SigmaString(str(val))
+        if self.target_type == "num":
+            try:
+                if isinstance(val, SigmaExpansion):
+                    for entry in val.values:
+                        float_value = float(str(entry))
+                        if float_value.is_integer():
+                            entry = SigmaNumber(int(str(entry)))
+                        else:
+                            entry = SigmaNumber(float(str(entry)))
+                    return val
+
+                float_value = float(str(val))
+                if float_value.is_integer():
+                    return SigmaNumber(int(str(val)))
+
+                return SigmaNumber(float_value)
+            except SigmaValueError as error:
+                raise SigmaValueError(f"Value '{val}' can't be converted to number for {str(self)}") from error
+
+        return val

--- a/sigma/pipelines/netwitness/__init__.py
+++ b/sigma/pipelines/netwitness/__init__.py
@@ -1,6 +1,6 @@
 """Mappings of identifier to pipelines used by pySigma"""
 
-from .windows import netwitness_windows_pipeline  # pylint:disable=import-error
+from .windows import netwitness_windows_pipeline
 
 pipelines = {
     "netwitness_windows": netwitness_windows_pipeline,

--- a/sigma/pipelines/netwitness/netwitness.py
+++ b/sigma/pipelines/netwitness/netwitness.py
@@ -4,9 +4,8 @@ from typing import List
 
 from sigma.processing.conditions import IncludeFieldCondition
 from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
-from sigma.processing.transformations import ConvertTypeTransformation
 
-from sigma.backends.netwitness.transformations import UnquoteStringTransformation
+from sigma.backends.netwitness.transformations import CustomConvertTypeTransformation, UnquoteStringTransformation
 from sigma.pipelines.netwitness.schemas import PipelinePriority
 
 field_transformations_to_string: List[str] = [
@@ -264,7 +263,7 @@ def netwitness_pipeline() -> ProcessingPipeline:
     processing_items.append(
         ProcessingItem(
             identifier="netwitness_transform_fields_to_string",
-            transformation=ConvertTypeTransformation(target_type="str"),
+            transformation=CustomConvertTypeTransformation(target_type="str"),
             field_name_conditions=[IncludeFieldCondition(fields=field_transformations_to_string)],
         )
     )
@@ -272,7 +271,7 @@ def netwitness_pipeline() -> ProcessingPipeline:
     processing_items.append(
         ProcessingItem(
             identifier="netwitness_transform_fields_to_number",
-            transformation=ConvertTypeTransformation(target_type="num"),
+            transformation=CustomConvertTypeTransformation(target_type="num"),
             field_name_conditions=[IncludeFieldCondition(fields=field_transformations_to_number)],
         )
     )

--- a/tests/test_pipelines_netwitness_windows.py
+++ b/tests/test_pipelines_netwitness_windows.py
@@ -82,3 +82,28 @@ def test_netwitness_param_contains_backslash(netwitness_backend_windows_pipeline
     )
 
     assert conversion_result == ["device.type = 'windows' && (reference.id = '4688' && param contains 'C:\\Windows')"]
+
+
+def test_windows_with_windash_modifier(netwitness_backend_windows_pipeline: NetWitnessBackend):
+    """Test basic field mapping and injection of the process creation condition"""
+
+    conversion_result: str = netwitness_backend_windows_pipeline.convert(
+        SigmaCollection.from_yaml(  # type: ignore
+            """
+            title: Test
+            status: test
+            logsource:
+                product: windows
+                category: process_creation
+            detection:
+                sel:
+                    CommandLine|windash|contains:
+                    - '-f'
+                condition: sel
+            """
+        )
+    )
+
+    assert conversion_result == [
+        "device.type = 'windows' && (reference.id = '4688' && (param contains '-f','/f','–f','—f','―f'))"
+    ]


### PR DESCRIPTION
Using sigma expansions in combination with string conversions results in a sigma expansion that wrapped into a string. This string is then plain converted into a query. Therefore the expansion is not unwrapped. A custom transformation was added to fix this issue.

Link to this issue in pysigma: https://github.com/SigmaHQ/pySigma/issues/328